### PR TITLE
chore: remove github-authentication-sessions entry from secrets when there are no sessions

### DIFF
--- a/src/provider-session-manager.spec.ts
+++ b/src/provider-session-manager.spec.ts
@@ -34,6 +34,7 @@ const extensionContextMock: extensionApi.ExtensionContext = {
     secrets: {
       get: vi.fn<(key: string) => Promise<string | undefined>>(),
       store: vi.fn<(key: string, value: string) => Promise<void>>(),
+      delete: vi.fn<(key: string) => Promise<void>>(),
     },
 } as unknown as extensionApi.ExtensionContext;
 
@@ -164,4 +165,14 @@ test('saveSessions', async () => {
   await sessionManager.saveSessions();
 
   expect(extensionContextMock.secrets.store).toHaveBeenCalledWith(AUTHENTICATION_SESSIONS_KEY, JSON.stringify([sessionsMock[0]]));
+});
+
+test('saveSessions with no sessions', async () => {
+  // make sure that there are no sessions saved
+  const currentSessions = await sessionManager.getSessions();
+  expect(currentSessions).toEqual([]);
+
+  await sessionManager.saveSessions();
+
+  expect(extensionContextMock.secrets.delete).toHaveBeenCalledWith(AUTHENTICATION_SESSIONS_KEY);
 });

--- a/src/provider-session-manager.ts
+++ b/src/provider-session-manager.ts
@@ -107,6 +107,10 @@ export class ProviderSessionManager {
   }
 
   async saveSessions(): Promise<void> {
-    await this.extensionContext.secrets.store(AUTHENTICATION_SESSIONS_KEY, JSON.stringify(this.ghSessions));
+    if (this.ghSessions.length === 0) {
+      await this.extensionContext.secrets.delete(AUTHENTICATION_SESSIONS_KEY);
+    } else {
+      await this.extensionContext.secrets.store(AUTHENTICATION_SESSIONS_KEY, JSON.stringify(this.ghSessions));
+    }
   }
 }


### PR DESCRIPTION
The `redhat.github-account.github-authentication-sessions` entry will be removed from the `safe-storage` file when there are no sessions