### PR TITLE
chore: update to node 24

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
       
       - name: Execute pnpm
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
        
       - name: Execute pnpm
@@ -91,7 +91,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
       
       - name: Execute pnpm

--- a/build/Containerfile.builder
+++ b/build/Containerfile.builder
@@ -15,7 +15,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM registry.access.redhat.com/ubi9/nodejs-22:9.6-1757333865
+FROM registry.access.redhat.com/ubi9/nodejs-24:9.7-1766414990
 
 COPY package.json .
 COPY pnpm-lock.yaml .


### PR DESCRIPTION
Update GitHub CI workflows and builder image to node 24
Closes https://github.com/podman-desktop/extension-github/issues/83