### PR TITLE
chore: update publisher name

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Sign in and authenticate with a GitHub account",
   "version": "0.2.0-next",
   "icon": "icon.png",
-  "publisher": "redhat",
+  "publisher": "podman-desktop",
   "license": "Apache-2.0",
   "engines": {
     "podman-desktop": "^1.19.0"


### PR DESCRIPTION
Updates the extension publisher name to `podman-desktop` instead of `redhat`
Closes https://github.com/podman-desktop/extension-github/issues/96