### PR TITLE
chore: add visible authentication action status

### DIFF
--- a/src/provider-session-manager.spec.ts
+++ b/src/provider-session-manager.spec.ts
@@ -126,7 +126,7 @@ test.each([
       'Could not complete GitHub authentication flow',
     );
     expect(extensionApi.window.showNotification).toBeCalledWith({
-      title: 'Could not complete GitHub authentication flow. Try again',
+      title: 'Could not complete GitHub authentication flow. Please try again.',
       type: 'error',
       highlight: true,
     });

--- a/src/provider-session-manager.ts
+++ b/src/provider-session-manager.ts
@@ -70,7 +70,7 @@ export class ProviderSessionManager {
 
     if (!newAuthSession) {
       extensionApi.window.showNotification({
-        title: 'Could not complete GitHub authentication flow. Try again',
+        title: 'Could not complete GitHub authentication flow. Please try again.',
         type: 'error',
         highlight: true,
       });


### PR DESCRIPTION
This PR adds a visible status update about the GitHub authentication action.
If the action is cancel by the user or some error is thrown (except for timeout), an error notification will show up.
If the action is successful, an info notification will show up

<img width="1156" height="835" alt="Screenshot 2026-01-14 at 9 18 49 PM" src="https://github.com/user-attachments/assets/6b90e3b3-d35d-41f3-9568-8c930d2b94af" />
<img width="1156" height="835" alt="Screenshot 2026-01-27 at 10 21 49 AM" src="https://github.com/user-attachments/assets/a9413468-788d-4ed2-8c8e-57de6b4cbf38" />

<img width="1156" height="835" alt="Screenshot 2026-01-14 at 9 04 58 PM" src="https://github.com/user-attachments/assets/66984a70-1bb6-4751-b6a4-a1570f23fbd3" />


Closes https://github.com/podman-desktop/extension-github/issues/95