### PR TITLE
fix: prevent activation timeout by not awaiting createSessionEntry

### DIFF
--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -35,6 +35,7 @@ const extensionContextMcok: extensionApi.ExtensionContext = {
 
 test('Session manager created and used upon extension activation', async () => {
   vi.mocked(extensionApi.commands.registerCommand).mockReturnValue({ dispose: vi.fn() });
+  vi.mocked(ProviderSessionManager.prototype.createSessionEntry).mockResolvedValue();
   await activate(extensionContextMcok);
   expect(ProviderSessionManager).toHaveBeenCalledWith(extensionContextMcok);
   expect(ProviderSessionManager.prototype.registerAuthenticationProvider).toHaveBeenCalled();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,13 @@ export async function activate(context: extensionApi.ExtensionContext): Promise<
 
   await providerSessionManager.registerAuthenticationProvider();
   await providerSessionManager.restoreSessions();
-  await providerSessionManager.createSessionEntry();
+
+  // Fire-and-forget: don't block activation on this call because
+  // getSession may show an interactive "Allow Access" dialog that
+  // exceeds the 20-second activation timeout.
+  providerSessionManager.createSessionEntry().catch((err: unknown) => {
+    console.error('Failed to create session entry', err);
+  });
 }
 
 // Deactivate the extension


### PR DESCRIPTION
## Summary

- `createSessionEntry()` calls `authentication.getSession()` which may show an interactive "Allow Access" dialog when restored sessions exist. Awaiting that call during `activate()` blocks the activation promise until the user responds, easily exceeding the 20-second timeout enforced by Podman Desktop's extension loader.
- Changed the call to fire-and-forget with error logging — the provider registration and session restoration (the essential parts) still complete before this point.

## Root cause

The activation sequence was:
1. `registerAuthenticationProvider()` — fast
2. `restoreSessions()` — loads saved sessions from secrets, fast
3. **`createSessionEntry()`** — calls `getSession('github-authentication', [], { createIfNone: false })`, which, when sessions exist, triggers an `isAccessAllowed` check that shows a blocking "Allow Access" MessageBox dialog

The 20s `withTimeout` wrapper in Podman Desktop's `activateExtension` fires before the user has a chance to interact with the dialog.

## What changed

`src/extension.ts`: Removed `await` from `createSessionEntry()` and added `.catch()` for error logging.

Fixes #174

> [!NOTE]
> AI assisted


Made with [Cursor](https://cursor.com)